### PR TITLE
uuid bug fixed by adding required model

### DIFF
--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -73,6 +73,7 @@ autobind:
 models:
   ID:
     model:
+      - github.com/husamettinarabaci/gqltool/uuid.Uuid
       - github.com/99designs/gqlgen/graphql.ID
       - github.com/99designs/gqlgen/graphql.Int32
       - github.com/99designs/gqlgen/graphql.Int
@@ -85,3 +86,6 @@ models:
   Timestamp:
     model:
       - github.com/husamettinarabaci/gqltool/timestamp.Timestamp
+  Uuid:
+    model:
+      - github.com/husamettinarabaci/gqltool/uuid.Uuid


### PR DESCRIPTION
Closes #8. 

Problem Description:

We have encountered a bug in our system related to ID data handling. While the system works correctly when an ID is posted with the correct format, it fails to handle incorrectly formatted IDs, instead converting the wrong data to an empty string. This behavior could lead to unexpected results and errors that users might not anticipate.

For example:
UserID : c742f0b0-b538-4dd9-9c5d-bbb8ceb50953 -> User Not Found
UserID : c742f0b0-b538-4dd9-9c5d-3c4d-bbb8ceb50953 -> Founded User[0] (this is admin)

Solution Approach:

To address this issue, you have created a new "graphql.Marshaler" for "uuid" using "gqlgen" within the "gqltool" project. However, to integrate this fix into your system, you need to update the models section in the "gqlgen.yml" configuration file.

Solution:

Update the models section as follows:
models:
  ID:
    model:
      - github.com/husamettinarabaci/gqltool/uuid.Uuid
      - github.com/99designs/gqlgen/graphql.ID
      - github.com/99designs/gqlgen/graphql.Int32
      - github.com/99designs/gqlgen/graphql.Int
      - github.com/99designs/gqlgen/graphql.Int64
  Int:
    model:
      - github.com/99designs/gqlgen/graphql.Int32
      - github.com/99designs/gqlgen/graphql.Int
      - github.com/99designs/gqlgen/graphql.Int64
  Timestamp:
    model:
      - github.com/husamettinarabaci/gqltool/timestamp.Timestamp
  Uuid:
    model:
      - github.com/husamettinarabaci/gqltool/uuid.Uuid
