### PR TITLE
Update GetErrors: DLR & Auth.

### DIFF
--- a/pkg/infrastructure/adapter/service/error.go
+++ b/pkg/infrastructure/adapter/service/error.go
@@ -18,8 +18,13 @@ func (a ServiceAdapter) GetErrors(ctx context.Context) (*pb.Errors, error) {
 	var pbResults pb.Errors
 	loggingErrors := a.GetErrorsDynamic(ctx, "GetLoggingErrors", tconfig.GetInternalConfigInstance().Grpc.LoggerHost, tconfig.GetInternalConfigInstance().Grpc.LoggerPort)
 	userErrors := a.GetErrorsDynamic(ctx, "GetUserErrors", tconfig.GetInternalConfigInstance().Grpc.UserHost, tconfig.GetInternalConfigInstance().Grpc.UserPort)
+	dlrErrors := a.GetErrorsDynamic(ctx, "GetDlrErrors", tconfig.GetInternalConfigInstance().Grpc.DlrHost, tconfig.GetInternalConfigInstance().Grpc.DlrPort)
+	authenticationErrors := a.GetErrorsDynamic(ctx, "GetAuthenticationErrors", tconfig.GetInternalConfigInstance().Grpc.AuthenticationHost, tconfig.GetInternalConfigInstance().Grpc.AuthenticationPort)
 	pbResults.Errors = append(pbResults.Errors, loggingErrors.Errors...)
 	pbResults.Errors = append(pbResults.Errors, userErrors.Errors...)
+	pbResults.Errors = append(pbResults.Errors, dlrErrors.Errors...)
+	pbResults.Errors = append(pbResults.Errors, authenticationErrors.Errors...)
+
 	return &pbResults, nil
 }
 


### PR DESCRIPTION
Closes #63 

The GetErrors function has been updated for DLR and Auth errors.